### PR TITLE
Improve EventEmitter robustness

### DIFF
--- a/inst/htmlwidgets/neurosurface/src/EventEmitter.js
+++ b/inst/htmlwidgets/neurosurface/src/EventEmitter.js
@@ -1,9 +1,13 @@
 export class EventEmitter {
   constructor() {
-    this._events = {};
+    // Use an object without a prototype to avoid prototype pollution
+    this._events = Object.create(null);
   }
 
   on(event, listener) {
+    if (typeof listener !== 'function') {
+      throw new TypeError('listener must be a function');
+    }
     if (!this._events[event]) {
       this._events[event] = [];
     }
@@ -11,9 +15,21 @@ export class EventEmitter {
     return () => this.removeListener(event, listener);
   }
 
+  once(event, listener) {
+    if (typeof listener !== 'function') {
+      throw new TypeError('listener must be a function');
+    }
+    const wrapped = (...args) => {
+      this.removeListener(event, wrapped);
+      listener(...args);
+    };
+    return this.on(event, wrapped);
+  }
+
   emit(event, ...args) {
     if (this._events[event]) {
-      this._events[event].forEach((listener) => listener(...args));
+      // Copy listeners to avoid issues if the array is modified during emit
+      [...this._events[event]].forEach((listener) => listener(...args));
     }
   }
 
@@ -22,6 +38,17 @@ export class EventEmitter {
       this._events[event] = this._events[event].filter(
         (listener) => listener !== listenerToRemove
       );
+      if (this._events[event].length === 0) {
+        delete this._events[event];
+      }
+    }
+  }
+
+  removeAllListeners(event) {
+    if (event) {
+      delete this._events[event];
+    } else {
+      this._events = Object.create(null);
     }
   }
 }


### PR DESCRIPTION
## Summary
- guard against prototype pollution in `EventEmitter`
- validate listeners and add `once`/`removeAllListeners` helpers
- avoid concurrent modifications during emit
- ensure trailing newline

## Testing
- `node - <<'NODE'
const {EventEmitter} = require('./inst/htmlwidgets/neurosurface/src/EventEmitter.js');
const emitter = new EventEmitter();
let count = 0;
const off = emitter.on('test', () => { count++; });
emitter.emit('test');
off();
emitter.emit('test');
let onceCount = 0;
emitter.once('once', () => { onceCount++; });
emitter.emit('once');
emitter.emit('once');
emitter.removeAllListeners();
console.log('OK');
NODE