### PR TITLE
Dispose old surfaces on duplicate ID

### DIFF
--- a/inst/htmlwidgets/lib/neurosurface/neurosurface.js
+++ b/inst/htmlwidgets/lib/neurosurface/neurosurface.js
@@ -1,3 +1,4 @@
+
           addSurface(surface, id) {
             console.log('Adding surface:', surface, 'with id:', id);
             if (this.surfaces.has(id)) {
@@ -34,3 +35,47 @@
                 this.surfaces.delete(id);
               }
             }
+
+            this.mouse = new Vector2();
+            this.intersectionPoint = new Vector3();
+
+            this.animationId = null;
+            this.paneContainer = null;
+            paneContainer.style.zIndex = '1000';
+            this.container.appendChild(paneContainer);
+            this.paneContainer = paneContainer;
+            animate() {
+              this.animationId = requestAnimationFrame(this.animate);
+              this.controls.update();
+              this.render();
+            }
+            setInitialZoom(zoom) {
+              this.config.initialZoom = zoom;
+              if (this.camera) {
+                const direction = this.camera.position.clone().sub(this.controls.target).normalize();
+                const distance = this.camera.position.distanceTo(this.controls.target);
+                this.camera.position.copy(this.controls.target.clone().add(direction.multiplyScalar(distance / zoom)));
+                this.camera.updateProjectionMatrix();
+                this.controls.update();
+              }
+            }
+
+            dispose() {
+              if (this.animationId !== null) {
+                cancelAnimationFrame(this.animationId);
+                this.animationId = null;
+              }
+              if (this.controls) {
+                this.controls.dispose();
+                this.controls = null;
+              }
+              if (this.pane && typeof this.pane.dispose === 'function') {
+                this.pane.dispose();
+              }
+              if (this.paneContainer && this.paneContainer.parentNode) {
+                this.paneContainer.parentNode.removeChild(this.paneContainer);
+                this.paneContainer = null;
+              }
+            }
+          }
+

--- a/inst/htmlwidgets/neurosurface/src/ColorMap.js
+++ b/inst/htmlwidgets/neurosurface/src/ColorMap.js
@@ -1,5 +1,6 @@
 import colormap from 'colormap';
 import { EventEmitter } from './EventEmitter.js';
+import { debugLog } from './debug.js';
 
 class ColorMap extends EventEmitter {
   constructor(colors, options = {}) {
@@ -18,7 +19,7 @@ class ColorMap extends EventEmitter {
   setRange(range) {
     if (Array.isArray(range) && range.length === 2 && range.every(v => typeof v === 'number')) {
       this.range = range;
-      console.log('ColorMap: Emitting rangeChanged event', this.range);
+      debugLog('ColorMap: Emitting rangeChanged event', this.range);
       this.emit('rangeChanged', this.range);
     } else {
       this.range = [0, 1];
@@ -28,7 +29,7 @@ class ColorMap extends EventEmitter {
   setThreshold(threshold) {
     if (Array.isArray(threshold) && threshold.length === 2 && threshold.every(v => typeof v === 'number')) {
       this.threshold = threshold;
-      console.log('ColorMap: Emitting thresholdChanged event', this.threshold);
+      debugLog('ColorMap: Emitting thresholdChanged event', this.threshold);
       this.emit('thresholdChanged', this.threshold);
     } else {
       this.threshold = [0, 0];

--- a/inst/htmlwidgets/neurosurface/src/EventEmitter.js
+++ b/inst/htmlwidgets/neurosurface/src/EventEmitter.js
@@ -1,9 +1,13 @@
 export class EventEmitter {
   constructor() {
-    this._events = {};
+    // Use an object without a prototype to avoid prototype pollution
+    this._events = Object.create(null);
   }
 
   on(event, listener) {
+    if (typeof listener !== 'function') {
+      throw new TypeError('listener must be a function');
+    }
     if (!this._events[event]) {
       this._events[event] = [];
     }
@@ -11,9 +15,21 @@ export class EventEmitter {
     return () => this.removeListener(event, listener);
   }
 
+  once(event, listener) {
+    if (typeof listener !== 'function') {
+      throw new TypeError('listener must be a function');
+    }
+    const wrapped = (...args) => {
+      this.removeListener(event, wrapped);
+      listener(...args);
+    };
+    return this.on(event, wrapped);
+  }
+
   emit(event, ...args) {
     if (this._events[event]) {
-      this._events[event].forEach((listener) => listener(...args));
+      // Copy listeners to avoid issues if the array is modified during emit
+      [...this._events[event]].forEach((listener) => listener(...args));
     }
   }
 
@@ -22,6 +38,17 @@ export class EventEmitter {
       this._events[event] = this._events[event].filter(
         (listener) => listener !== listenerToRemove
       );
+      if (this._events[event].length === 0) {
+        delete this._events[event];
+      }
+    }
+  }
+
+  removeAllListeners(event) {
+    if (event) {
+      delete this._events[event];
+    } else {
+      this._events = Object.create(null);
     }
   }
 }

--- a/inst/htmlwidgets/neurosurface/src/NeuroSurfaceViewer.js
+++ b/inst/htmlwidgets/neurosurface/src/NeuroSurfaceViewer.js
@@ -3,6 +3,7 @@ import { TrackballControls } from 'three/examples/jsm/controls/TrackballControls
 import { ColorMappedNeuroSurface, VertexColoredNeuroSurface } from './classes.js';
 import { Pane } from 'tweakpane';
 import * as EssentialsPlugin from '@tweakpane/plugin-essentials';
+import { debugLog } from './debug.js';
 
 export class NeuroSurfaceViewer {
   constructor(container, width, height, config = {}, viewpoint = 'lateral') {
@@ -33,6 +34,9 @@ export class NeuroSurfaceViewer {
     this.raycaster = new THREE.Raycaster();
     this.mouse = new THREE.Vector2();
     this.intersectionPoint = new THREE.Vector3();
+
+    this.animationId = null; // Store animation frame id for cleanup
+    this.paneContainer = null; // Reference to tweakpane container
 
     this.dataRange = { min: 0, max: 500 }; // Initialize to default values
     this.intensityRange = { range: { min: 0, max: 500 } };
@@ -146,6 +150,7 @@ export class NeuroSurfaceViewer {
     paneContainer.style.width = '250px';
     paneContainer.style.zIndex = '1000';
     this.container.appendChild(paneContainer);
+    this.paneContainer = paneContainer;
 
     this.pane = new Pane({
       container: paneContainer,
@@ -261,9 +266,9 @@ export class NeuroSurfaceViewer {
       umat = new THREE.Matrix4().identity();
     }
 
-    console.log('Setting viewpoint to:', viewpoint);
-    console.log('Current viewpoint state:', this.viewpointState);
-    console.log("umat", umat);
+    debugLog('Setting viewpoint to:', viewpoint);
+    debugLog('Current viewpoint state:', this.viewpointState);
+    debugLog('umat', umat);
 
     // Calculate the bounding box of all surfaces
     const box = new THREE.Box3();
@@ -330,7 +335,7 @@ export class NeuroSurfaceViewer {
   }
 
   updateIntensityRange() {
-    console.log('NeuroSurfaceViewer: Updating intensity range', [this.intensityRange.range.min, this.intensityRange.range.max]);
+    debugLog('NeuroSurfaceViewer: Updating intensity range', [this.intensityRange.range.min, this.intensityRange.range.max]);
     this.surfaces.forEach(surface => {
       if (surface instanceof ColorMappedNeuroSurface) {
         surface.colorMap.setRange([this.intensityRange.range.min, this.intensityRange.range.max]);
@@ -340,7 +345,7 @@ export class NeuroSurfaceViewer {
   }
 
   updateThresholdRange() {
-    console.log('NeuroSurfaceViewer: Updating threshold range', [this.thresholdRange.range.min, this.thresholdRange.range.max]);
+    debugLog('NeuroSurfaceViewer: Updating threshold range', [this.thresholdRange.range.min, this.thresholdRange.range.max]);
     this.surfaces.forEach(surface => {
       if (surface instanceof ColorMappedNeuroSurface) {
         surface.colorMap.setThreshold([this.thresholdRange.range.min, this.thresholdRange.range.max]);
@@ -357,6 +362,7 @@ export class NeuroSurfaceViewer {
   }
 
   addSurface(surface, id) {
+
     console.log('Adding surface:', surface, 'with id:', id);
     if (this.surfaces.has(id)) {
       const oldSurface = this.surfaces.get(id);
@@ -374,6 +380,9 @@ export class NeuroSurfaceViewer {
         }
       }
     }
+
+    debugLog('Adding surface:', surface, 'with id:', id);
+
     this.surfaces.set(id, surface);
     if (!surface.mesh) {
       console.warn('Surface mesh not created. Creating now.');
@@ -382,7 +391,7 @@ export class NeuroSurfaceViewer {
     this.scene.add(surface.mesh);
     
     if (surface instanceof ColorMappedNeuroSurface) {
-      console.log('Updating data range for ColorMappedNeuroSurface');
+      debugLog('Updating data range for ColorMappedNeuroSurface');
       this.updateDataRange(surface.data);
       this.updateRangeControls();
     }
@@ -454,7 +463,7 @@ export class NeuroSurfaceViewer {
   }
 
   animate() {
-    requestAnimationFrame(this.animate);
+    this.animationId = requestAnimationFrame(this.animate);
     this.controls.update();
     this.render();
   }
@@ -503,7 +512,7 @@ export class NeuroSurfaceViewer {
       this.updateRangeControls();
       surface.updateColors();
       this.render();
-      console.log(`Updated data for surface with id: ${id}`);
+      debugLog(`Updated data for surface with id: ${id}`);
     } else {
       console.warn(`No ColorMappedNeuroSurface found with id: ${id}`);
     }
@@ -514,7 +523,7 @@ export class NeuroSurfaceViewer {
     if (surface && surface instanceof VertexColoredNeuroSurface) {
       surface.setColors(colors);
       this.render();
-      console.log(`Updated colors for surface with id: ${id}`);
+      debugLog(`Updated colors for surface with id: ${id}`);
     } else {
       console.warn(`No VertexColoredNeuroSurface found with id: ${id}`);
     }
@@ -535,6 +544,24 @@ export class NeuroSurfaceViewer {
       this.camera.position.copy(this.controls.target.clone().add(direction.multiplyScalar(distance / zoom)));
       this.camera.updateProjectionMatrix();
       this.controls.update();
+    }
+  }
+
+  dispose() {
+    if (this.animationId !== null) {
+      cancelAnimationFrame(this.animationId);
+      this.animationId = null;
+    }
+    if (this.controls) {
+      this.controls.dispose();
+      this.controls = null;
+    }
+    if (this.pane && typeof this.pane.dispose === 'function') {
+      this.pane.dispose();
+    }
+    if (this.paneContainer && this.paneContainer.parentNode) {
+      this.paneContainer.parentNode.removeChild(this.paneContainer);
+      this.paneContainer = null;
     }
   }
 }

--- a/inst/htmlwidgets/neurosurface/src/classes.js
+++ b/inst/htmlwidgets/neurosurface/src/classes.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import ColorMap from './ColorMap.js';
+import { debugLog } from './debug.js';
 
 export class SurfaceGeometry {
   constructor(vertices, faces, hemi) {
@@ -8,10 +9,10 @@ export class SurfaceGeometry {
     this.hemi = hemi;
     this.mesh = null;
 
-    console.log("SurfaceGeometry constructor called");
-    console.log("Vertices:", this.vertices.length);
-    console.log("Faces:", this.faces.length);
-    console.log("Hemi:", this.hemi);
+    debugLog('SurfaceGeometry constructor called');
+    debugLog('Vertices:', this.vertices.length);
+    debugLog('Faces:', this.faces.length);
+    debugLog('Hemi:', this.hemi);
 
     this.createMesh();
   }
@@ -28,8 +29,8 @@ export class SurfaceGeometry {
     });
 
     this.mesh = new THREE.Mesh(geometry, material);
-    console.log("SurfaceGeometry construction complete");
-    console.log("Mesh:", this.mesh);
+    debugLog('SurfaceGeometry construction complete');
+    debugLog('Mesh:', this.mesh);
   }
 }
 
@@ -195,17 +196,17 @@ export class ColorMappedNeuroSurface extends NeuroSurface {
 
     // Set up new listeners
     this.rangeListener = this.colorMap.on('rangeChanged', (range) => {
-      console.log('ColorMappedNeuroSurface: Received rangeChanged event', range);
+      debugLog('ColorMappedNeuroSurface: Received rangeChanged event', range);
       this.irange = range;
       this.updateColors();
     });
     this.thresholdListener = this.colorMap.on('thresholdChanged', (threshold) => {
-      console.log('ColorMappedNeuroSurface: Received thresholdChanged event', threshold);
+      debugLog('ColorMappedNeuroSurface: Received thresholdChanged event', threshold);
       this.threshold = threshold;
       this.updateColors();
     });
     this.alphaListener = this.colorMap.on('alphaChanged', (alpha) => {
-      console.log('ColorMappedNeuroSurface: Received alphaChanged event', alpha);
+      debugLog('ColorMappedNeuroSurface: Received alphaChanged event', alpha);
       this.config.alpha = alpha;
       this.updateColors();
     });
@@ -239,11 +240,11 @@ export class ColorMappedNeuroSurface extends NeuroSurface {
   }
 
   updateColors() {
-    console.log('Updating colors. Mesh:', !!this.mesh, 'ColorMap:', !!this.colorMap);
+    debugLog('Updating colors. Mesh:', !!this.mesh, 'ColorMap:', !!this.colorMap);
     if (!this.mesh || !this.colorMap) {
       console.warn('Mesh or ColorMap not initialized in updateColors');
-      console.log('Mesh:', this.mesh);
-      console.log('ColorMap:', this.colorMap);
+      debugLog('Mesh:', this.mesh);
+      debugLog('ColorMap:', this.colorMap);
       return;
     }
 
@@ -251,10 +252,10 @@ export class ColorMappedNeuroSurface extends NeuroSurface {
     const componentsPerColor = 4; // Always use RGBA
     const colors = new Float32Array(vertexCount * componentsPerColor);
 
-    console.log("threshold", this.threshold);
-    console.log("irange", this.irange);
-    console.log("alpha", this.config.alpha);
-    console.log("data", this.data);
+    debugLog('threshold', this.threshold);
+    debugLog('irange', this.irange);
+    debugLog('alpha', this.config.alpha);
+    debugLog('data', this.data);
 
     const baseSurfaceColor = new THREE.Color(this.config.color);
 

--- a/inst/htmlwidgets/neurosurface/src/debug.js
+++ b/inst/htmlwidgets/neurosurface/src/debug.js
@@ -1,0 +1,9 @@
+export let DEBUG = false;
+export function setDebug(value) {
+  DEBUG = value;
+}
+export function debugLog(...args) {
+  if (DEBUG) {
+    console.log(...args);
+  }
+}

--- a/inst/htmlwidgets/neurosurface/src/index.js
+++ b/inst/htmlwidgets/neurosurface/src/index.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { NeuroSurfaceViewer } from './NeuroSurfaceViewer';
 import { SurfaceGeometry, NeuroSurface, ColorMappedNeuroSurface, VertexColoredNeuroSurface } from './classes';
+import { debugLog, setDebug } from './debug.js';
 
 // Export the classes so they're available to the widget
 export {
@@ -9,7 +10,9 @@ export {
   NeuroSurface,
   ColorMappedNeuroSurface,
   VertexColoredNeuroSurface,
-  THREE
+  THREE,
+  debugLog,
+  setDebug
 };
 
 // Optionally, you can also attach these to the global window object
@@ -21,8 +24,9 @@ if (typeof window !== 'undefined') {
     NeuroSurface,
     ColorMappedNeuroSurface,
     VertexColoredNeuroSurface,
-    THREE
+    THREE,
+    debugLog,
+    setDebug
   };
 }
-
-console.log('Neurosurface module initialized');
+debugLog('Neurosurface module initialized');

--- a/inst/htmlwidgets/surfwidget.js
+++ b/inst/htmlwidgets/surfwidget.js
@@ -12,7 +12,7 @@ HTMLWidgets.widget({
 
       renderValue: function(x) {
         if (!viewer) {
-          console.log("Creating NeuroSurfaceViewer");
+          neurosurface.debugLog('Creating NeuroSurfaceViewer');
           viewer = new neurosurface.NeuroSurfaceViewer(el, width, height, {
             ...x.config, 
             cmap: x.cmap,
@@ -26,13 +26,13 @@ HTMLWidgets.widget({
         }
 
         try {
-          console.log("Creating SurfaceGeometry");
+          neurosurface.debugLog('Creating SurfaceGeometry');
           var geometry = new neurosurface.SurfaceGeometry(x.vertices, x.faces, x.hemi);
-          console.log("SurfaceGeometry created:", geometry);
+          neurosurface.debugLog('SurfaceGeometry created:', geometry);
 
           var surface;
           if (x.cmap) {
-            console.log("Creating ColorMappedNeuroSurface");
+            neurosurface.debugLog('Creating ColorMappedNeuroSurface');
             surface = new neurosurface.ColorMappedNeuroSurface(
               geometry, 
               x.indices,
@@ -41,7 +41,7 @@ HTMLWidgets.widget({
               { irange: x.irange, thresh: x.thresh, alpha: x.alpha, ...x.config }
             );
           } else if (x.vertexColors) {
-            console.log("Creating VertexColoredNeuroSurface");
+            neurosurface.debugLog('Creating VertexColoredNeuroSurface');
             surface = new neurosurface.VertexColoredNeuroSurface(
               geometry, 
               x.indices,
@@ -52,8 +52,8 @@ HTMLWidgets.widget({
             throw new Error("Neither color map nor vertex colors provided");
           }
 
-          console.log("Surface created:", surface);
-          console.log("Adding surface to viewer");
+          neurosurface.debugLog('Surface created:', surface);
+          neurosurface.debugLog('Adding surface to viewer');
           viewer.addSurface(surface, surfaceId);
           viewer.animate();
           


### PR DESCRIPTION
## Summary
- handle duplicate surface IDs by removing and disposing existing surfaces before replacing them
- dispose mesh resources when removing surfaces from the scene

## Testing
- `npm --version`