### PR TITLE
Improve ColorMap validation

### DIFF
--- a/inst/htmlwidgets/neurosurface/src/ColorMap.js
+++ b/inst/htmlwidgets/neurosurface/src/ColorMap.js
@@ -35,26 +35,46 @@ class ColorMap extends EventEmitter {
     }
   }
 
+  /**
+   * Normalize and validate a color specification.
+   * Colors may be provided as a hex string (with or without leading '#') or as
+   * an array of numeric components in the range [0, 1].
+   *
+   * @param {string|number[]} color The color to parse.
+   * @returns {number[]} Array of normalized RGB or RGBA components.
+   */
   parseColor(color) {
     if (typeof color === 'string' && color.startsWith('#')) {
       return this.hexToRgb(color);
     }
-    if (Array.isArray(color) && (color.length === 3 || color.length === 4) && color.every(v => typeof v === 'number')) {
+    if (
+      Array.isArray(color) &&
+      (color.length === 3 || color.length === 4) &&
+      color.every(v => Number.isFinite(v) && v >= 0 && v <= 1)
+    ) {
       return color;
     }
     throw new TypeError('Invalid color format');
   }
 
+  /**
+   * Convert a hex color string to normalized RGB(A) components.
+   *
+   * @param {string} hex Hexadecimal color string starting with '#'. May include
+   *                     an optional alpha channel.
+   * @returns {number[]} Array of RGB or RGBA components in the range [0, 1].
+   */
   hexToRgb(hex) {
-    // Remove the hash at the start if it's there
     hex = hex.replace(/^#/, '');
 
-    // Parse the r, g, b values
+    if (!/^[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(hex)) {
+      throw new Error('Invalid hex color');
+    }
+
     const r = parseInt(hex.slice(0, 2), 16) / 255;
     const g = parseInt(hex.slice(2, 4), 16) / 255;
     const b = parseInt(hex.slice(4, 6), 16) / 255;
 
-    // Check if there's an alpha channel
     if (hex.length === 8) {
       const a = parseInt(hex.slice(6, 8), 16) / 255;
       return [r, g, b, a];

--- a/man/ColorMappedNeuroSurface-class.Rd
+++ b/man/ColorMappedNeuroSurface-class.Rd
@@ -11,6 +11,7 @@ mapped to colors using a specified colormap and range.
 \details{
 This class extends \code{NeuroSurface} by adding color mapping functionality.
 The \code{cmap} slot contains a vector of hex color codes that define the colormap.
+Alternatively, it can be a matrix of RGB(A) rows with numeric components between 0 and 1.
 The \code{irange} slot specifies the range of data values to be mapped to the colormap.
 The \code{thresh} slot defines the visibility thresholds: data values below \code{thresh[1]}
 or above \code{thresh[2]} are visible, while values in between are not visible.


### PR DESCRIPTION
## Summary
- validate color arrays and hex string lengths in `ColorMap`
- document that `cmap` can be a matrix of normalized RGB(A) values

## Testing
- `npm run build` *(fails: gulp not found)*