### PR TITLE
Update custom message type for widget config

### DIFF
--- a/R/surfwidget.R
+++ b/R/surfwidget.R
@@ -178,11 +178,12 @@ renderSurfwidget <- function(expr, env = parent.frame(), quoted = FALSE) {
 #' @param session The \code{session} object passed to function given to \code{shinyServer}.
 #' @param id The ID of the surfwidget output.
 #' @param config A list of configuration options to update. See \code{\link{surfwidget}} for details on available options.
+#' @details Sends a custom message of type \code{"neurosurf-surfwidget-config"} to update the widget configuration on the client.
 #'
 #' @export
 updateSurfwidgetConfig <- function(session, id, config) {
-  message <- list(config = config)
-  session$sendCustomMessage(type = 'surfwidget-config', message)
+  message <- list(id = id, config = config)
+  session$sendCustomMessage(type = 'neurosurf-surfwidget-config', message)
 }
 
 #' @export

--- a/inst/htmlwidgets/surfwidget.js
+++ b/inst/htmlwidgets/surfwidget.js
@@ -99,3 +99,12 @@ HTMLWidgets.widget({
     };
   }
 });
+
+if (HTMLWidgets.shinyMode) {
+  Shiny.addCustomMessageHandler('neurosurf-surfwidget-config', function(message) {
+    var widget = HTMLWidgets.find('#' + message.id);
+    if (widget && widget.updateConfig) {
+      widget.updateConfig(message.config);
+    }
+  });
+}

--- a/man/updateSurfwidgetConfig.Rd
+++ b/man/updateSurfwidgetConfig.Rd
@@ -15,4 +15,5 @@ updateSurfwidgetConfig(session, id, config)
 }
 \description{
 Update the configuration of an existing surfwidget.
+This sends a \code{"neurosurf-surfwidget-config"} custom message to the client.
 }


### PR DESCRIPTION
## Summary
- send `neurosurf-surfwidget-config` message from `updateSurfwidgetConfig`
- document the message type
- listen for the new message type in `surfwidget.js`

## Testing
- `npm --version`
- `Rscript --version` *(fails: command not found)*