### PR TITLE
Remove debugging prints

### DIFF
--- a/R/all_class.R
+++ b/R/all_class.R
@@ -1022,10 +1022,9 @@ setClass("ColorMappedNeuroSurface",
            if (length(object@thresh) != 2) {
              stop("'thresh' must be a numeric vector of length 2")
            }
-           if (!(object@irange[1] <= object@irange[2])) {
-             print(paste(object@irange[1], ",", object@irange[2]))
-             stop("'irange[1]' must be less than or equal to 'irange[2]'")
-           }
+          if (!(object@irange[1] <= object@irange[2])) {
+            stop("'irange[1]' must be less than or equal to 'irange[2]'")
+          }
            if (!(object@thresh[1] <= object@thresh[1])) {
              stop("'thresh[1]' must be less than or equal to 'thresh[2]'")
            }

--- a/R/spec.R
+++ b/R/spec.R
@@ -16,7 +16,6 @@ load_spec <- function(spec) {
   }))
 
   keyval <- lapply(newsurf_lines, function(ns) {
-    print(ns)
     lnum <- ns
     vars <- list()
     keys <- list()
@@ -88,7 +87,6 @@ load_spec <- function(spec) {
   }))
 
   keyval <- lapply(newsurf_lines, function(ns) {
-    print(ns)
     lnum <- ns
     vars <- list()
     keys <- list()

--- a/R/surfwidget.R
+++ b/R/surfwidget.R
@@ -54,7 +54,6 @@ setMethod("surfwidget", signature(x = "NeuroSurface"),
     if (is.null(irange)) {
       irange <- range(x@data)
     }
-    print(irange)
     # Create a ColorMappedNeuroSurface and call its method
     color_mapped_surface <- ColorMappedNeuroSurface(x@geometry, x@indices, x@data, cmap = cmap,
                                 irange = irange, thresh=thresh)


### PR DESCRIPTION
## Summary
- remove stray `print` from `surfwidget()`
- drop debugging prints from `load_spec()` and `ColorMappedNeuroSurface` validity checks

## Testing
- `grep -n "print(" -R | head`