### PR TITLE
Fix animation duplication

### DIFF
--- a/inst/htmlwidgets/surfwidget.js
+++ b/inst/htmlwidgets/surfwidget.js
@@ -55,7 +55,9 @@ HTMLWidgets.widget({
           neurosurface.debugLog('Surface created:', surface);
           neurosurface.debugLog('Adding surface to viewer');
           viewer.addSurface(surface, surfaceId);
-          viewer.animate();
+          if (viewer.animationId === null) {
+            viewer.animate();
+          }
           
         } catch (error) {
           console.error("Error in renderValue:", error);


### PR DESCRIPTION
## Summary
- avoid repeatedly starting the animation loop in `surfwidget.js`

## Testing
- `npm run build` *(fails: gulp not found)*