### PR TITLE
Fix color map listener cleanup

### DIFF
--- a/inst/htmlwidgets/neurosurface/src/classes.js
+++ b/inst/htmlwidgets/neurosurface/src/classes.js
@@ -171,9 +171,18 @@ export class ColorMappedNeuroSurface extends NeuroSurface {
   setColorMap(colorMap) {
     if (this.colorMap) {
       // Remove old listeners
-      this.rangeListener();
-      this.thresholdListener();
-      this.alphaListener();
+      if (typeof this.rangeListener === 'function') {
+        this.rangeListener();
+        this.rangeListener = null;
+      }
+      if (typeof this.thresholdListener === 'function') {
+        this.thresholdListener();
+        this.thresholdListener = null;
+      }
+      if (typeof this.alphaListener === 'function') {
+        this.alphaListener();
+        this.alphaListener = null;
+      }
     }
 
     if (!(colorMap instanceof ColorMap)) {


### PR DESCRIPTION
## Summary
- guard old listener removal in `setColorMap`

## Testing
- `npm run build` *(fails: gulp not found)*
- `R CMD build .` *(fails: command not found)*