### PR TITLE
Rename AFNI data meta constructor

### DIFF
--- a/R/IO.R
+++ b/R/IO.R
@@ -467,7 +467,7 @@ read_surf_data_seq <- function(leftGeometry, rightGeometry, leftDataNames, right
 #' @importMethodsFrom neuroim2 read_meta_info
 setMethod(f="read_meta_info",signature=signature(x= "AFNISurfaceFileDescriptor"),
           def=function(x, file_name) {
-            .read_meta_info(x, file_name, readAFNISurfaceHeader, AFNISurfaceDataMetaInfo)
+            .read_meta_info(x, file_name, readAFNISurfaceHeader, NIMLSurfaceDataMetaInfoFromAFNI)
           })
 
 #' @rdname read_meta_info
@@ -798,11 +798,12 @@ NIMLSurfaceDataMetaInfo <- function(descriptor, header) {
       node_indices=as.integer(header$nodes))
 }
 
-#' Constructor for \code{AFNISurfaceDataMetaInfo} class
+#' Create a \code{NIMLSurfaceDataMetaInfo} instance from an AFNI header
+#'
 #' @param descriptor the file descriptor
 #' @param header a \code{list} containing header information
 #' @noRd
-AFNISurfaceDataMetaInfo <- function(descriptor, header) {
+NIMLSurfaceDataMetaInfoFromAFNI <- function(descriptor, header) {
   stopifnot(is.numeric(header$nodes))
 
   new("NIMLSurfaceDataMetaInfo",

--- a/docs/reference/NIMLSurfaceDataMetaInfoFromAFNI.html
+++ b/docs/reference/NIMLSurfaceDataMetaInfoFromAFNI.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Constructor for <code>AFNISurfaceDataMetaInfo</code> class — AFNISurfaceDataMetaInfo • neurosurf</title>
+<title>Constructor for <code>NIMLSurfaceDataMetaInfoFromAFNI</code> class — NIMLSurfaceDataMetaInfoFromAFNI • neurosurf</title>
 
 
 <!-- jquery -->
@@ -35,8 +35,8 @@
 
 
 
-<meta property="og:title" content="Constructor for <code>AFNISurfaceDataMetaInfo</code> class — AFNISurfaceDataMetaInfo" />
-<meta property="og:description" content="Constructor for AFNISurfaceDataMetaInfo class" />
+<meta property="og:title" content="Constructor for <code>NIMLSurfaceDataMetaInfoFromAFNI</code> class — NIMLSurfaceDataMetaInfoFromAFNI" />
+<meta property="og:description" content="Constructor for NIMLSurfaceDataMetaInfoFromAFNI class" />
 <meta name="twitter:card" content="summary" />
 
 
@@ -117,16 +117,16 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Constructor for <code>AFNISurfaceDataMetaInfo</code> class</h1>
+    <h1>Constructor for <code>NIMLSurfaceDataMetaInfoFromAFNI</code> class</h1>
     <small class="dont-index">Source: <a href='https://github.com/bbuchsbaum/neurosurf/blob/master/R/IO.R'><code>R/IO.R</code></a></small>
-    <div class="hidden name"><code>AFNISurfaceDataMetaInfo.Rd</code></div>
+    <div class="hidden name"><code>NIMLSurfaceDataMetaInfoFromAFNI.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    <p>Constructor for <code>AFNISurfaceDataMetaInfo</code> class</p>
+    <p>Constructor for <code>NIMLSurfaceDataMetaInfoFromAFNI</code> class</p>
     </div>
 
-    <pre class="usage"><span class='fu'>AFNISurfaceDataMetaInfo</span>(<span class='no'>descriptor</span>, <span class='no'>header</span>)</pre>
+    <pre class="usage"><span class='fu'>NIMLSurfaceDataMetaInfoFromAFNI</span>(<span class='no'>descriptor</span>, <span class='no'>header</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">

--- a/docs/reference/vol_to_surf.html
+++ b/docs/reference/vol_to_surf.html
@@ -171,7 +171,7 @@ TODO does this work?</p></td>
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'>
 <span class='no'>volname</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://rdrr.io/r/base/system.file.html'>system.file</a></span>(<span class='st'>"inst/testdata/Schaefer2018_200Parcels_7Networks_order_FSLMNI152_1mm.nii"</span>, <span class='kw'>package</span><span class='kw'>=</span><span class='st'>"neurosurf"</span>)
-<span class='no'>vol</span> <span class='kw'>&lt;-</span> <span class='kw pkg'>neuroim2</span><span class='kw ns'>::</span><span class='fu'><a href='https://rdrr.io/pkg/neuroim2/man/read_vol.html'>read_vol</a></span>(<span class='no'>volname</span>)</div><div class='output co'>#&gt; <span class='error'>Error in read_header(input): could not find reader for file:  AFNISurfaceDataMetaInfo.html</span></div></pre>
+<span class='no'>vol</span> <span class='kw'>&lt;-</span> <span class='kw pkg'>neuroim2</span><span class='kw ns'>::</span><span class='fu'><a href='https://rdrr.io/pkg/neuroim2/man/read_vol.html'>read_vol</a></span>(<span class='no'>volname</span>)</div><div class='output co'>#&gt; <span class='error'>Error in read_header(input): could not find reader for file:  NIMLSurfaceDataMetaInfoFromAFNI.html</span></div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>


### PR DESCRIPTION
## Summary
- avoid implying non-existent `AFNISurfaceDataMetaInfo` class
- rename constructor to `NIMLSurfaceDataMetaInfoFromAFNI`
- update `read_meta_info` call and docs

## Testing
- `git diff --name-status --staged`
