### PR TITLE
Fix data_reader class targeting

### DIFF
--- a/R/IO.R
+++ b/R/IO.R
@@ -650,36 +650,29 @@ loadFSSurface <- function(meta_info) {
 #' @rdname data_reader
 #' @importClassesFrom neuroim2 ColumnReader
 #' @noRd
-setMethod(f="data_reader", signature=signature("SurfaceGeometryMetaInfo"),
+setMethod(f="data_reader", signature=signature("SurfaceDataMetaInfo"),
           def=function(x) {
+            if (!all(c("data", "node_indices") %in% slotNames(x))) {
+              stop("data_reader requires 'data' and 'node_indices' slots",
+                   call. = FALSE)
+            }
             reader <- function(i) {
               if (length(i) == 1 && i == 0) {
                 x@node_indices
               } else {
-                x@data[,i,drop=FALSE]
+                x@data[, i, drop = FALSE]
               }
             }
 
-            neuroim2::ColumnReader(nrow=as.integer(nrow(x@data)), ncol=as.integer(ncol(x@data)), reader=reader)
+            neuroim2::ColumnReader(nrow = as.integer(nrow(x@data)),
+                                   ncol = as.integer(ncol(x@data)),
+                                   reader = reader)
           })
 
 
 
 #' @rdname data_reader
 #' @noRd
-setMethod(f="data_reader", signature=signature("NIMLSurfaceDataMetaInfo"),
-          def=function(x) {
-            reader <- function(i) {
-              if (length(i) == 1 && i == 0) {
-                x@node_indices
-              } else {
-                x@data[,i,drop=FALSE]
-              }
-            }
-
-            neuroim2::ColumnReader(nrow=as.integer(nrow(x@data)), ncol=as.integer(ncol(x@data)), reader=reader)
-            #new("ColumnReader", nrow=as.integer(nrow(x@data)), ncol=as.integer(ncol(x@data)), reader=reader)
-          })
 
 
 

--- a/tests/testthat/test_data_reader.R
+++ b/tests/testthat/test_data_reader.R
@@ -1,0 +1,9 @@
+test_that("data_reader works for SurfaceDataMetaInfo", {
+  niml_file <- system.file("extdata", "rscan01_lh.niml.dset", package = "neurosurf")
+  header <- readNIMLSurfaceHeader(niml_file)
+  meta <- NIMLSurfaceDataMetaInfo(NIML_SURFACE_DSET, header)
+
+  reader <- data_reader(meta)
+  nodes <- neuroim2::read_columns(reader, as.integer(0))
+  expect_equal(as.integer(nodes), meta@node_indices)
+})


### PR DESCRIPTION
## Summary
- define `data_reader` for `SurfaceDataMetaInfo` instead of `SurfaceGeometryMetaInfo`
- remove stale `NIMLSurfaceDataMetaInfo` method
- test that `data_reader` works for a `SurfaceDataMetaInfo` subclass

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: `bash: R: command not found`)*