### PR TITLE
Fix docs for read_meta_info

### DIFF
--- a/R/IO.R
+++ b/R/IO.R
@@ -462,7 +462,7 @@ read_surf_data_seq <- function(leftGeometry, rightGeometry, leftDataNames, right
 #' read_meta_info
 #'
 #' @param x the file descriptor object
-#' @param file_name the name of the file containing meta infromation.
+#' @param file_name the name of the file containing meta information.
 #' @rdname read_meta_info
 #' @importMethodsFrom neuroim2 read_meta_info
 setMethod(f="read_meta_info",signature=signature(x= "AFNISurfaceFileDescriptor"),

--- a/man/read_meta_info.Rd
+++ b/man/read_meta_info.Rd
@@ -21,7 +21,7 @@
 \arguments{
 \item{x}{the file descriptor object}
 
-\item{file_name}{the name of the file containing meta infromation.}
+\item{file_name}{the name of the file containing meta information.}
 }
 \description{
 read_meta_info


### PR DESCRIPTION
## Summary
- fix typo in IO.R roxygen comment
- update man page accordingly

## Testing
- `Rscript -e "roxygen2::roxygenise()"` *(fails: Rscript not found)*