### PR TITLE
Fix hemisphere grep logic

### DIFF
--- a/R/IO.R
+++ b/R/IO.R
@@ -151,9 +151,9 @@ readFreesurferAsciiGeometry <- function(file_name) {
 readFreesurferBinaryHeader <- function(file_name) {
   has_hemi <- grep("^[lr]h\\..*", basename(file_name))
   hemi <- if (length(has_hemi) > 0) {
-    if (length(grep("^lh.*", basename(file_name))>0)) {
+    if (length(grep("^lh.*", basename(file_name))) > 0) {
       "lh"
-    } else if (length(grep("^rh.*", basename(file_name))>0)) {
+    } else if (length(grep("^rh.*", basename(file_name))) > 0) {
       "rh"
     } else {
       "unknown"

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -14,5 +14,15 @@ test_that("can read a niml 4D data file", {
   expect_true(TRUE)
 })
 
+test_that("readFreesurferBinaryHeader hemisphere detection works", {
+  lh_file <- system.file("extdata", "std.8_lh.pial.asc", package = "neurosurf")
+  lh_hdr <- neurosurf:::readFreesurferBinaryHeader(lh_file)
+  expect_equal(lh_hdr$hemi, "lh")
+
+  rh_file <- system.file("extdata", "std.8_rh.pial.asc", package = "neurosurf")
+  rh_hdr <- neurosurf:::readFreesurferBinaryHeader(rh_file)
+  expect_equal(rh_hdr$hemi, "rh")
+})
+
 
 


### PR DESCRIPTION
## Summary
- fix grep expression in `readFreesurferBinaryHeader`
- add unit test covering hemisphere detection

## Testing
- `R -e 'testthat::test_dir("tests/testthat")'` *(fails: R not installed)*