### PR TITLE
Remove unused roi_surface_matrix function

### DIFF
--- a/R/ROI.R
+++ b/R/ROI.R
@@ -70,18 +70,6 @@ SurfaceDisk <- function(surf, index, radius, max_order=NULL) {
 
 }
 
-
-roi_surface_matrix <- function(mat, refspace, indices, coords) {
-  structure(mat,
-            refspace=refspace,
-            indices=indices,
-            coords=coords,
-            class=c("roi_surface_matrix", "matrix"))
-
-}
-
-
-
 #' values
 #'
 #' @param x the object to extract values from


### PR DESCRIPTION
## Summary
- drop `roi_surface_matrix` helper from `ROI.R`
- fix missing closing brace after removal

## Testing
- `R CMD check` *(fails: `bash: R: command not found`)*