### PR TITLE
Fix random deflist ordering

### DIFF
--- a/R/Searchlight.R
+++ b/R/Searchlight.R
@@ -17,12 +17,18 @@
 #' @details
 #' On each call to \code{nextElem}, a set of surface nodes is returned.
 #' These nodes index into the vertices of the \code{igraph} instance.
+#' When \code{as_deflist=TRUE}, the random ordering of centers is fixed when the
+#' object is created. Use \code{set.seed} before construction for reproducible
+#' sequences.
 #'
 #' @examples
 #' \dontrun{
 #' file <- system.file("extdata", "std.8_lh.smoothwm.asc", package = "neurosurf")
 #' geom <- read_surf(file)
 #' searchlight <- RandomSurfaceSearchlight(geom, 12)
+#' set.seed(42)
+#' dl <- RandomSurfaceSearchlight(geom, 12, as_deflist=TRUE)
+#' attr(dl[[1]], "center")
 #' nodes <- searchlight$nextElem()
 #' length(nodes) > 1
 #' }
@@ -53,10 +59,13 @@ RandomSurfaceSearchlight <- function(surfgeom, radius=8, nodeset=NULL, as_deflis
   prog <- function() { sum(done)/length(done) }
 
   if (as_deflist) {
+    # precompute random order of remaining nodes
+    order <- sample(which(!done))
+
     # Create function to get nth element
     fun <- function(n) {
-      if (n > length(nds)) stop("Index out of bounds")
-      center <- which(!done)[n]
+      if (n > length(order)) stop("Index out of bounds")
+      center <- order[n]
       indices <- as.vector(igraph::neighborhood(bg, 1, nds[center])[[1]])
       indices <- indices[!done[indices]]
 
@@ -74,7 +83,7 @@ RandomSurfaceSearchlight <- function(surfgeom, radius=8, nodeset=NULL, as_deflis
       }
     }
 
-    return(deflist::deflist(fun, len=sum(!done)))
+    return(deflist::deflist(fun, len=length(order)))
   }
 
   nextEl <- function() {

--- a/tests/testthat/test_searchlight.R
+++ b/tests/testthat/test_searchlight.R
@@ -83,3 +83,18 @@ test_that("RandomSurfaceSearchlight deflist works correctly", {
   expect_false(is.null(attr(nodes, "center")))
   expect_false(is.null(attr(nodes, "length")))
 })
+
+test_that("RandomSurfaceSearchlight deflist uses random ordering", {
+  surf_file <- system.file("extdata", "std.8_lh.inflated.asc", package="neurosurf")
+  surf <- read_surf(surf_file)
+
+  set.seed(1)
+  sl1 <- RandomSurfaceSearchlight(surf, radius=12, as_deflist=TRUE)
+  first1 <- attr(sl1[[1]], "center")
+
+  set.seed(2)
+  sl2 <- RandomSurfaceSearchlight(surf, radius=12, as_deflist=TRUE)
+  first2 <- attr(sl2[[1]], "center")
+
+  expect_false(identical(first1, first2))
+})


### PR DESCRIPTION
## Summary
- fix RandomSurfaceSearchlight deflist to use random order
- document new behavior and example
- test that order differs under different seeds

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*