### PR TITLE
Fix read_meta_info generic

### DIFF
--- a/R/all_generic.R
+++ b/R/all_generic.R
@@ -205,12 +205,17 @@ setGeneric(name="plot_js", def=function(x, width = NULL, height = NULL, ...) sta
 
 
 
-# Generic function to read image meta info given a file and a \code{\linkS4class{FileFormat}} instance.
-# @param x file format
-# @param file_name file name contianing meta information
-# @export
-# @rdname read_meta_info-methods
-setGeneric(name="read_meta_info", def=function(x, file_name) standardGeneric("read_meta_info"))
+#' Generic function to read image meta info given a file and a \code{\linkS4class{FileFormat}} instance.
+#'
+#' @param x file format
+#' @param file_name file name containing meta information
+#'
+#' @export
+#' @rdname read_meta_info-methods
+if (!isGeneric("read_meta_info")) {
+  setGeneric(name = "read_meta_info",
+             def = function(x, file_name) standardGeneric("read_meta_info"))
+}
 
 
 


### PR DESCRIPTION
## Summary
- roxygenize docs for `read_meta_info`
- fix typo in documentation
- avoid redefining generic if imported

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`