### PR TITLE
Handle cycles in edge_faces boundaries

### DIFF
--- a/R/boundaries.R
+++ b/R/boundaries.R
@@ -480,12 +480,39 @@ find_roi_boundaries <- function(vertices, faces, vertex_id, boundary_method = "m
         sp <- igraph::shortest_paths(G, from = N1, to = N2, output = "vpath")$vpath[[1]]
 
         attempts <- 0
-        while (any(!(component_nodes %in% sp)) && attempts < 10) {
-          # Handle cycles and disconnected nodes
-          # Implement complex logic to adjust adjacency matrix
-          # For brevity, we simplify the process
+        repeat {
+          missing_nodes <- setdiff(component_nodes, sp)
+          cycle_closed <- length(sp) > 1 && adj[sp[length(sp)], sp[1]] > 0
+
+          if (length(missing_nodes) == 0 && cycle_closed) {
+            break
+          }
+
+          if (attempts >= 10) {
+            break
+          }
+
           attempts <- attempts + 1
-          break
+
+          if (length(missing_nodes) > 0) {
+            cand <- missing_nodes[1]
+          } else {
+            cand <- sp[length(sp)]
+          }
+
+          neigh <- which(adj[cand, ] > 0)
+          if (length(neigh) == 0) {
+            break
+          }
+
+          adj[cand, neigh[1]] <- 0
+          adj[neigh[1], cand] <- 0
+
+          G <- igraph::graph_from_adjacency_matrix(adj, mode = "undirected")
+          sp <- igraph::shortest_paths(G, from = N1, to = N2, output = "vpath")$vpath[[1]]
+          if (length(sp) == 0) {
+            break
+          }
         }
 
         if (attempts >= 10) {

--- a/tests/testthat/test_boundaries_edge_faces.R
+++ b/tests/testthat/test_boundaries_edge_faces.R
@@ -1,0 +1,26 @@
+library(testthat)
+library(neurosurf)
+
+test_that("edge_faces handles complex ROI boundaries", {
+  vertices <- matrix(c(
+    0, 0, 0,
+    1, 0, 0,
+    1, 1, 0,
+    0, 1, 0,
+    0.5, 0.5, 0
+  ), ncol = 3, byrow = TRUE)
+
+  faces <- matrix(c(
+    1, 2, 5,
+    2, 3, 5,
+    3, 4, 5,
+    4, 1, 5
+  ), ncol = 3, byrow = TRUE)
+
+  vertex_id <- c(1, 1, 1, 1, 2)
+
+  res <- find_roi_boundaries(vertices, faces, vertex_id, boundary_method = "edge_faces")
+  expect_true(length(res$boundary) >= 1)
+  expect_true(all(vapply(res$boundary_verts, length, integer(1)) >= 4))
+})
+


### PR DESCRIPTION
## Summary
- detect missing nodes and cycle closure when tracing edge_faces boundaries
- iteratively modify adjacency to try to build a full cycle
- warn if repeated attempts fail
- add regression test for complex ROI boundaries

## Testing
- `R -q -e "devtools::test()"` *(fails: `bash: R: command not found`)*