### PR TITLE
Randomize deflist order in searchlights

### DIFF
--- a/R/Searchlight.R
+++ b/R/Searchlight.R
@@ -53,28 +53,29 @@ RandomSurfaceSearchlight <- function(surfgeom, radius=8, nodeset=NULL, as_deflis
   prog <- function() { sum(done)/length(done) }
 
   if (as_deflist) {
+    order <- sample.int(length(nds))
     # Create function to get nth element
     fun <- function(n) {
-      if (n > length(nds)) stop("Index out of bounds")
-      center <- which(!done)[n]
-      indices <- as.vector(igraph::neighborhood(bg, 1, nds[center])[[1]])
+      if (n > length(order)) stop("Index out of bounds")
+      idx <- order[n]
+      indices <- as.vector(igraph::neighborhood(bg, 1, nds[idx])[[1]])
       indices <- indices[!done[indices]]
 
       if (subgraph) {
         vout <- nodeset[indices]
-        attr(vout, "center") <- nodeset[center]
-        attr(vout, "center.index") <- nodeset[center]
+        attr(vout, "center") <- nodeset[idx]
+        attr(vout, "center.index") <- nodeset[idx]
         attr(vout, "length") <- length(vout)
         vout
       } else {
-        attr(indices, "center") <- center
-        attr(indices, "center.index") <- center
+        attr(indices, "center") <- idx
+        attr(indices, "center.index") <- idx
         attr(indices, "length") <- length(indices)
         indices
       }
     }
 
-    return(deflist::deflist(fun, len=sum(!done)))
+    return(deflist::deflist(fun, len=length(order)))
   }
 
   nextEl <- function() {

--- a/tests/testthat/test_searchlight.R
+++ b/tests/testthat/test_searchlight.R
@@ -83,3 +83,18 @@ test_that("RandomSurfaceSearchlight deflist works correctly", {
   expect_false(is.null(attr(nodes, "center")))
   expect_false(is.null(attr(nodes, "length")))
 })
+
+test_that("RandomSurfaceSearchlight deflist order changes with seed", {
+  surf_file <- system.file("extdata", "std.8_lh.inflated.asc", package="neurosurf")
+  surf <- read_surf(surf_file)
+
+  set.seed(123)
+  sl1 <- RandomSurfaceSearchlight(surf, radius=12, as_deflist=TRUE)
+  centers1 <- vapply(seq_len(length(sl1)), function(i) attr(sl1[[i]], "center.index"), numeric(1))
+
+  set.seed(124)
+  sl2 <- RandomSurfaceSearchlight(surf, radius=12, as_deflist=TRUE)
+  centers2 <- vapply(seq_len(length(sl2)), function(i) attr(sl2[[i]], "center.index"), numeric(1))
+
+  expect_false(identical(centers1, centers2))
+})


### PR DESCRIPTION
## Summary
- randomize deflist order in `RandomSurfaceSearchlight`
- expose number of searchlights via `len`
- add unit test to check RNG affects deflist order

## Testing
- `R CMD build .` *(fails: command not found)*