### PR TITLE
Clamp spherical acos input and add test

### DIFF
--- a/R/neighborhood.R
+++ b/R/neighborhood.R
@@ -116,7 +116,9 @@ find_all_neighbors <- function(surf, radius, edgeWeights, nodes=NULL,
       D <- c(0, all_can$nn.dist[v,])
     } else if (distance_type == "spherical") {
       ind <- all_can$nn.index[v,]
-      ang <- acos(sin(lat[v]) * sin(lat[ind]) + cos(lat[v]) * cos(lat[ind]) * cos(abs(lon[v] - lon[ind])))
+      cos_val <- sin(lat[v]) * sin(lat[ind]) + cos(lat[v]) * cos(lat[ind]) * cos(abs(lon[v] - lon[ind]))
+      cos_val <- pmin(pmax(cos_val, -1), 1)
+      ang <- acos(cos_val)
       D <- c(0, R * ang)
     }
 

--- a/tests/testthat/test_neighborhood_spherical.R
+++ b/tests/testthat/test_neighborhood_spherical.R
@@ -1,0 +1,13 @@
+library(neurosurf)
+
+test_that("find_all_neighbors spherical distances produce no NaN", {
+  surf_file <- system.file("extdata", "std.8_lh.sphere.asc", package="neurosurf")
+  surf <- read_surf(surf_file)
+  g <- graph(surf)
+  edgeWeights <- igraph::E(g)$dist
+  nb <- find_all_neighbors(surf, radius = 12, edgeWeights = edgeWeights,
+                           nodes = 1:5, distance_type = "spherical")
+  dvals <- unlist(lapply(nb, function(x) x[ ,"d"]))
+  expect_false(any(is.nan(dvals)))
+})
+


### PR DESCRIPTION
## Summary
- clamp the argument to `acos()` in `find_all_neighbors`
- add a unit test checking spherical distance calculations do not produce `NaN`

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: `Rscript` not found)*