### PR TITLE
Cap k and validate inputs in find_all_neighbors

### DIFF
--- a/R/neighborhood.R
+++ b/R/neighborhood.R
@@ -41,8 +41,8 @@ findNeighbors <- function(graph, node, radius, edgeWeights, max_order=NULL) {
 #' Identifies all neighboring nodes within a specified radius for a given surface mesh.
 #'
 #' @param surf A SurfaceGeometry object or igraph object representing the mesh
-#' @param radius Numeric; the spatial radius within which to search for neighbors
-#' @param edgeWeights Numeric vector; weights for edges used in distance computation
+#' @param radius Numeric; the spatial radius within which to search for neighbors. Must be positive.
+#' @param edgeWeights Numeric vector; weights for edges used in distance computation. Length must equal the number of edges.
 #' @param nodes Integer vector; subset of nodes to find neighbors for. If NULL, uses all nodes
 #' @param distance_type Character; type of distance metric to use: "euclidean", "geodesic", or "spherical"
 #'
@@ -54,6 +54,8 @@ findNeighbors <- function(graph, node, radius, edgeWeights, max_order=NULL) {
 #' @details
 #' The function supports three distance metrics: Euclidean, geodesic, and spherical.
 #' For spherical distances, the surface is assumed to be a sphere.
+#' The internal k-nearest-neighbor search is capped at \code{vcount(g) - 1} to avoid
+#' requesting more neighbors than exist in the graph.
 #'
 #' @importFrom FNN get.knn
 #' @importFrom stats quantile
@@ -92,13 +94,23 @@ find_all_neighbors <- function(surf, radius, edgeWeights, nodes=NULL,
 
   distance_type <- match.arg(distance_type)
 
+  if (!is.numeric(radius) || length(radius) != 1 || radius <= 0) {
+    stop("radius must be a positive numeric value")
+  }
+
+  if (!is.numeric(edgeWeights) || length(edgeWeights) != igraph::ecount(g)) {
+    stop("edgeWeights must be a numeric vector with one value per edge")
+  }
+
   avg_weight <- stats::quantile(edgeWeights, .25)
 
   if (is.null(nodes)) {
     nodes <- igraph::V(g)
   }
 
-  all_can <- FNN::get.knn(coords(surf), k=ceiling((radius+2)/avg_weight)^3)
+  k_est <- ceiling((radius + 2) / avg_weight)^3
+  k <- min(k_est, igraph::vcount(g) - 1)
+  all_can <- FNN::get.knn(coords(surf), k = k)
 
   cds <- coords(g)
 

--- a/man/find_all_neighbors.Rd
+++ b/man/find_all_neighbors.Rd
@@ -15,9 +15,9 @@ find_all_neighbors(
 \arguments{
 \item{surf}{A SurfaceGeometry object or igraph object representing the mesh}
 
-\item{radius}{Numeric; the spatial radius within which to search for neighbors}
+\item{radius}{Numeric; the spatial radius within which to search for neighbors. Must be positive}
 
-\item{edgeWeights}{Numeric vector; weights for edges used in distance computation}
+\item{edgeWeights}{Numeric vector; weights for edges used in distance computation. Length must equal the number of edges}
 
 \item{nodes}{Integer vector; subset of nodes to find neighbors for. If NULL, uses all nodes}
 
@@ -35,6 +35,8 @@ Identifies all neighboring nodes within a specified radius for a given surface m
 \details{
 The function supports three distance metrics: Euclidean, geodesic, and spherical.
 For spherical distances, the surface is assumed to be a sphere.
+The internal k-nearest-neighbor search is capped at \code{vcount(g) - 1} to avoid
+requesting more neighbors than exist in the graph.
 }
 \examples{
 # Load a sample inflated surface from the package

--- a/tests/testthat/test_find_all_neighbors.R
+++ b/tests/testthat/test_find_all_neighbors.R
@@ -1,0 +1,12 @@
+test_that("find_all_neighbors validates inputs", {
+  surf_file <- system.file("extdata", "std.8_lh.inflated.asc", package = "neurosurf")
+  surf <- read_surf(surf_file)
+  g <- graph(surf)
+  edge_weights <- rep(1, length(E(g)))
+
+  expect_error(find_all_neighbors(surf, radius = 0, edgeWeights = edge_weights))
+  expect_error(find_all_neighbors(surf, radius = -1, edgeWeights = edge_weights))
+  bad_weights <- edge_weights[-1]
+  expect_error(find_all_neighbors(surf, radius = 5, edgeWeights = bad_weights))
+  expect_error(find_all_neighbors(surf, radius = 5, edgeWeights = "a"))
+})


### PR DESCRIPTION
## Summary
- add input validation for `radius` and `edgeWeights`
- cap `FNN::get.knn` query at `vcount(g) - 1`
- document new constraints
- add regression tests for invalid inputs

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: `R` command not found)*