### PR TITLE
Fix merge conflict in RandomSurfaceSearchlight

### DIFF
--- a/R/Searchlight.R
+++ b/R/Searchlight.R
@@ -63,39 +63,23 @@ RandomSurfaceSearchlight <- function(surfgeom, radius=8, nodeset=NULL, as_deflis
   prog <- function() { sum(done)/length(done) }
 
   if (as_deflist) {
-###<<<<<<< codex/update-randomsurfacesearchlight-with-random-permutation
     order <- sample.int(length(nds))
-    # Create function to get nth element
-    fun <- function(n) {
-      if (n > length(order)) stop("Index out of bounds")
-      idx <- order[n]
-      indices <- as.vector(igraph::neighborhood(bg, 1, nds[idx])[[1]])
-#### =======
-    # precompute random order of remaining nodes
-    order <- sample(which(!done))
 
     # Create function to get nth element
     fun <- function(n) {
-#### === codex/modify-fun-functions-to-check-n->=-1
-      if (n < 1 || n > length(nds)) stop("Index out of bounds")
-      center <- which(!done)[n]
-##### =======
-      if (n > length(order)) stop("Index out of bounds")
+      if (n < 1 || n > length(order)) stop("Index out of bounds")
       center <- order[n]
-#### >>>>>>> master
       indices <- as.vector(igraph::neighborhood(bg, 1, nds[center])[[1]])
-###>>>>>>> master
-      indices <- indices[!done[indices]]
 
       if (subgraph) {
         vout <- nodeset[indices]
-        attr(vout, "center") <- nodeset[idx]
-        attr(vout, "center.index") <- nodeset[idx]
+        attr(vout, "center") <- nodeset[center]
+        attr(vout, "center.index") <- nodeset[center]
         attr(vout, "length") <- length(vout)
         vout
       } else {
-        attr(indices, "center") <- idx
-        attr(indices, "center.index") <- idx
+        attr(indices, "center") <- center
+        attr(indices, "center.index") <- center
         attr(indices, "length") <- length(indices)
         indices
       }


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from `RandomSurfaceSearchlight`
- clean up and finalise random ordering logic for deflist mode

## Testing
- `R` command not found